### PR TITLE
Allow '.' and '=' in values set using --set flag

### DIFF
--- a/lib/__tests__/cloudworker-e2e.test.js
+++ b/lib/__tests__/cloudworker-e2e.test.js
@@ -58,7 +58,7 @@ describe('cloudworker-e2e', async () => {
 
   test('streams', async () => {
     const script = utils.read(path.join(__dirname, 'fixtures/worker-streams.js'))
-    const server = new Cloudworker(script, {debug: true}).listen(8080)
+    const server = new Cloudworker(script).listen(8080)
     const res = await axios.get('http://localhost:8080', defaultAxiosOpts)
     expect(res.status).toEqual(200)
     expect(res.data).toEqual('B')

--- a/lib/__tests__/utils.test.js
+++ b/lib/__tests__/utils.test.js
@@ -12,4 +12,11 @@ describe('utils', () => {
     expect(await test.get('key')).toEqual('value')
     expect(await another.get('key1')).toEqual('value1')
   })
+
+  test('extractKVBindings allows = and . in value', async () => {
+    const bindings = utils.extractKVBindings(['test.key=somevalue=.test1'])
+    const {test} = bindings
+
+    expect(await test.get('key')).toEqual('somevalue=.test1')
+  })
 })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,12 +5,15 @@ module.exports.extractKVBindings = (setFlagValues) => {
   const bindings = {}
   for (const flag of setFlagValues) {
     const comps = flag.split('.')
-
-    if (comps.length !== 2 || comps[1].split('=').length !== 2) {
+    if (comps.length < 2 || comps[1].split('=').length < 2) {
       throw new Error('Invalid set flag format. Expected format of [variable].[key]=[value]')
     }
+
     const variable = comps[0]
-    const [key, value] = comps[1].split('=')
+    const kvFragment = comps.slice(1).join('.')
+    const kvComponents = kvFragment.split('=')
+    const key = kvComponents[0]
+    const value = kvComponents.slice(1).join('=')
 
     if (!bindings[variable]) {
       bindings[variable] = new KeyValueStore()


### PR DESCRIPTION
This fixes a bug where parsing of values set using --set would fail parsing if they included '.' or '='.