### PR TITLE
Use More Spec Compliant Fetch Polyfill

### DIFF
--- a/lib/__tests__/cloudworker-e2e.test.js
+++ b/lib/__tests__/cloudworker-e2e.test.js
@@ -84,8 +84,35 @@ describe('cloudworker-e2e', async () => {
       res.end()
     }).listen(8081)
 
-    expect.assertions(1)
-    await axios.post('http://localhost:8080', 'testdata', defaultAxiosOpts)
+    expect.assertions()
+    const res = await axios.post('http://localhost:8080', 'testdata', defaultAxiosOpts)
+    expect(res.status).toEqual(200)
+
+    await server.close()
+    await upstream.close()
+  })
+
+  test('simple upstream response', async () => {
+    const script = `
+      addEventListener('fetch', async event => {
+        const incoming = event.request
+        const upstream = new Request('http://localhost:8081/')
+        const resp = await fetch(upstream)
+        event.respondWith(resp)
+      })
+    `
+    const server = new Cloudworker(script).listen(8080)
+    const upstream = http.createServer((req, res) => {
+      res.writeHead(404)
+      res.write('test of upstream non-200 status')
+      res.end()
+    }).listen(8081)
+
+    expect.assertions(2)
+    const res = await axios.get('http://localhost:8080', defaultAxiosOpts)
+    expect(res.status).toEqual(404)
+    expect(res.data).toEqual('test of upstream non-200 status')
+
     await server.close()
     await upstream.close()
   })
@@ -146,5 +173,31 @@ describe('cloudworker-e2e', async () => {
     expect(res.status).toEqual(200)
     expect(Buffer.from(res.data)).toEqual(Buffer.from(new Uint16Array([10, 20])))
     await server.close()
+  })
+
+  test('post upstream and echo response using streams', async () => {
+    const script = utils.read(path.join(__dirname, 'fixtures/worker-streams-cf.js'))
+    const server = new Cloudworker(script).listen(8080)
+
+    let postedBody = ''
+    const upstream = http.createServer((req, res) => {
+      req.on('data', chunk => {
+        postedBody += chunk.toString()
+        res.write(postedBody)
+      })
+      req.on('end', () => {
+        res.end()
+      })
+    }).listen(8081)
+
+    expect.assertions(3)
+    const expectedBody = 'testdata'
+    const res = await axios.post('http://localhost:8080', 'testdata', defaultAxiosOpts)
+    expect(postedBody).toEqual(expectedBody)
+    expect(res.status).toEqual(200)
+    expect(res.data).toEqual(expectedBody)
+
+    await server.close()
+    await upstream.close()
   })
 })

--- a/lib/__tests__/cloudworker-e2e.test.js
+++ b/lib/__tests__/cloudworker-e2e.test.js
@@ -5,7 +5,6 @@ const { KeyValueStore } = require('../kv')
 const axios = require('axios')
 const path = require('path')
 const http = require('http')
-const stream = require('stream')
 const defaultAxiosOpts = {validateStatus: () => true}
 
 describe('cloudworker-e2e', async () => {
@@ -87,34 +86,6 @@ describe('cloudworker-e2e', async () => {
 
     expect.assertions(1)
     await axios.post('http://localhost:8080', 'testdata', defaultAxiosOpts)
-    await server.close()
-    await upstream.close()
-  })
-
-  test('simple post chunked', async () => {
-    const script = `
-      addEventListener('fetch', async event => {
-        const incoming = event.request
-        const upstream = new Request('http://localhost:8081/', { body: incoming.body, method: incoming.method })
-        const resp = await fetch(upstream)
-        event.respondWith(resp)
-      })
-    `
-
-    const server = new Cloudworker(script).listen(8080)
-    const upstream = http.createServer(async (req, res) => {
-      const te = req.headers['transfer-encoding'] || ''
-      expect(te.includes('chunked')).toEqual(true)
-      res.end()
-    }).listen(8081)
-
-    expect.assertions(1)
-
-    var body = new stream.Readable()
-    body.push('test-data')
-    body.push(null)
-
-    await axios.post('http://localhost:8080', body, defaultAxiosOpts)
     await server.close()
     await upstream.close()
   })

--- a/lib/__tests__/cloudworker-e2e.test.js
+++ b/lib/__tests__/cloudworker-e2e.test.js
@@ -8,7 +8,7 @@ const http = require('http')
 const defaultAxiosOpts = {validateStatus: () => true}
 
 describe('cloudworker-e2e', async () => {
-  test('simple 200', async () => {
+  test('simple 200', async (cb) => {
     const script = `
       addEventListener('fetch', event => {
         event.respondWith(new Response('hello', {status: 200}))
@@ -19,9 +19,10 @@ describe('cloudworker-e2e', async () => {
     expect(res.status).toEqual(200)
     expect(res.data).toEqual('hello')
     await server.close()
+    cb()
   })
 
-  test('simple non-200', async () => {
+  test('simple non-200', async (cb) => {
     const script = `
       addEventListener('fetch', event => {
         event.respondWith(new Response('goodbye', {status: 400}))
@@ -32,9 +33,10 @@ describe('cloudworker-e2e', async () => {
     expect(res.status).toEqual(400)
     expect(res.data).toEqual('goodbye')
     await server.close()
+    cb()
   })
 
-  test('simple streaming response', async () => {
+  test('simple streaming response', async (cb) => {
     const script = `
       addEventListener('fetch', event => {
         const want = new Uint16Array([66])
@@ -50,9 +52,10 @@ describe('cloudworker-e2e', async () => {
     expect(res.data).toEqual('B') // 66
     expect(res.headers['transfer-encoding'].includes('chunked')).toEqual(true)
     await server.close()
+    cb()
   })
 
-  test('simple post', async () => {
+  test('simple post', async (cb) => {
     const script = `
       addEventListener('fetch', async event => {
         const incoming = event.request
@@ -66,9 +69,10 @@ describe('cloudworker-e2e', async () => {
     expect(res.data).toEqual('testdata')
 
     await server.close()
+    cb()
   })
 
-  test('simple post not chunked', async () => {
+  test('simple post not chunked', async (cb) => {
     const script = `
       addEventListener('fetch', async event => {
         const incoming = event.request
@@ -90,9 +94,10 @@ describe('cloudworker-e2e', async () => {
 
     await server.close()
     await upstream.close()
+    cb()
   })
 
-  test('simple upstream response', async () => {
+  test('simple upstream response', async (cb) => {
     const script = `
       addEventListener('fetch', async event => {
         const incoming = event.request
@@ -115,9 +120,10 @@ describe('cloudworker-e2e', async () => {
 
     await server.close()
     await upstream.close()
+    cb()
   })
 
-  test('cache', async () => {
+  test('cache', async (cb) => {
     const script = utils.read(path.join(__dirname, 'fixtures/cache-simple.js'))
     const server = new Cloudworker(script, {enableCache: true}).listen(8080)
 
@@ -142,9 +148,10 @@ describe('cloudworker-e2e', async () => {
     expect(res.headers['cf-cache-status']).toBeUndefined()
 
     await server.close()
+    cb()
   })
 
-  test('wasm', async () => {
+  test('wasm', async (cb) => {
     const script = utils.read(path.join(__dirname, 'fixtures/worker-wasm-simple.js'))
     const bindings = {Wasm: await wasm.loadPath(path.join(__dirname, 'fixtures/simple.wasm'))}
     const server = new Cloudworker(script, {bindings: bindings}).listen(8080)
@@ -152,9 +159,10 @@ describe('cloudworker-e2e', async () => {
     expect(res.status).toEqual(200)
     expect(res.data).toEqual(42)
     await server.close()
+    cb()
   })
 
-  test('kv', async () => {
+  test('kv', async (cb) => {
     const script = utils.read(path.join(__dirname, 'fixtures/worker-kv-simple.js'))
     const store = new KeyValueStore()
     store.put('hello', 'world')
@@ -164,18 +172,20 @@ describe('cloudworker-e2e', async () => {
     expect(res.status).toEqual(200)
     expect(res.data).toEqual('world')
     await server.close()
+    cb()
   })
 
-  test('streams', async () => {
+  test('streams', async (cb) => {
     const script = utils.read(path.join(__dirname, 'fixtures/worker-streams.js'))
     const server = new Cloudworker(script).listen(8080)
     const res = await axios({method: 'get', url: 'http://localhost:8080', responseType: 'arraybuffer'})
     expect(res.status).toEqual(200)
     expect(Buffer.from(res.data)).toEqual(Buffer.from(new Uint16Array([10, 20])))
     await server.close()
+    cb()
   })
 
-  test('post upstream and echo response using streams', async () => {
+  test('post upstream and echo response using streams', async (cb) => {
     const script = utils.read(path.join(__dirname, 'fixtures/worker-streams-cf.js'))
     const server = new Cloudworker(script).listen(8080)
 
@@ -199,5 +209,6 @@ describe('cloudworker-e2e', async () => {
 
     await server.close()
     await upstream.close()
+    cb()
   })
 })

--- a/lib/__tests__/cloudworker.test.js
+++ b/lib/__tests__/cloudworker.test.js
@@ -24,17 +24,17 @@ describe('cloudworker', () => {
     expect(console.log).toBeCalled()
   })
 
-  test('pipe sends appropriate headers', () => {
+  test('pipe sends appropriate headers', async () => {
     const cw = new Cloudworker(simpleScript)
     const srcRes = new runtime.Response('world', {headers: {'content-length': '100', 'content-encoding': '200', other: 'value'}})
     const dstRes = httpMocks.createResponse()
-    cw.pipe(srcRes, dstRes)
+    await cw.pipe(srcRes, dstRes)
     expect(dstRes.getHeader('other')).toEqual(['value'])
     expect(dstRes.getHeader('content-length')).toEqual(undefined)
     expect(dstRes.getHeader('content-encoding')).toEqual(undefined)
   })
 
-  test('pipe sends headers with multiple values', () => {
+  test('pipe sends headers with multiple values', async () => {
     const cw = new Cloudworker(simpleScript)
     const cookie1 = 'foo=value1'
     const cookie2 = 'bar=value2'
@@ -48,19 +48,19 @@ describe('cloudworker', () => {
 
     const srcRes = new runtime.Response('world', {headers: headers})
     const dstRes = httpMocks.createResponse()
-    cw.pipe(srcRes, dstRes)
+    await cw.pipe(srcRes, dstRes)
     expect(dstRes.getHeader('Set-Cookie')).toEqual([cookie1, cookie2])
   })
 
-  test('pipe pipes string body', () => {
+  test('pipe pipes string body', async () => {
     const cw = new Cloudworker(simpleScript)
     const srcRes = new runtime.Response('world')
     const dstRes = httpMocks.createResponse()
-    cw.pipe(srcRes, dstRes)
-    expect(dstRes._getData()).toEqual('world')
+    await cw.pipe(srcRes, dstRes)
+    expect(dstRes._getBuffer()).toEqual(Buffer.from('world', 'utf8'))
   })
 
-  test('pipe pipes buffer body', () => {
+  test('pipe pipes buffer body', async () => {
     const cw = new Cloudworker(simpleScript)
     const want = new Uint8Array([65])
     const srcRes = new runtime.Response(want)
@@ -69,7 +69,7 @@ describe('cloudworker', () => {
     dstRes.on('end', () => {
       expect(dstRes._getBuffer().compare(want)).toEqual(0)
     })
-    cw.pipe(srcRes, dstRes)
+    await cw.pipe(srcRes, dstRes)
   })
 
   test('pipe pipes stream body', done => {

--- a/lib/__tests__/fixtures/worker-streams-cf.js
+++ b/lib/__tests__/fixtures/worker-streams-cf.js
@@ -1,0 +1,29 @@
+addEventListener("fetch", event => {
+  event.respondWith(fetchAndStream(event.request))
+})
+
+async function fetchAndStream(request) {
+
+  let req = new Request('http://localhost:8081', request)
+
+  // Fetch from origin server.
+  let response = await fetch(req)
+  let { readable, writable } = new TransformStream()
+  streamBody(response.body, writable)
+
+  return new Response(readable, response)
+}
+
+async function streamBody(readable, writable) {
+  let reader = readable.getReader()
+  let writer = writable.getWriter()
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    // Optionally transform value's bytes here.
+    await writer.write(value)
+  }
+
+  await writer.close()
+}

--- a/lib/cloudworker.js
+++ b/lib/cloudworker.js
@@ -3,7 +3,6 @@ const vm = require('vm')
 const runtime = require('./runtime')
 const EventEmitter = require('events')
 const moment = require('moment')
-const nodeStream = require('stream')
 const StubCacheFactory = require('./runtime/cache/stub')
 const CacheFactory = require('./runtime/cache/cache')
 
@@ -50,19 +49,20 @@ class Cloudworker {
     runtime.freezeHeaders(request.headers)
 
     const respondWith = async (callBackResp) => {
-      const loggingCb = () => {
+      const log = () => {
         const end = new Date()
         this.logRequest(req, res, start, end)
       }
 
       try {
         callBackResp = await callBackResp
-        this.pipe(callBackResp, res, loggingCb)
+        await this.pipe(callBackResp, res)
       } catch (error) {
         this.logDebugError(error)
         res.statusCode = 500
         res.end()
-        loggingCb()
+      } finally {
+        log()
       }
     }
 
@@ -86,46 +86,18 @@ class Cloudworker {
     }
   }
 
-  pipe (srcRes, dstRes, callback) {
-    var headers = srcRes.headers.raw()
+  async pipe (srcRes, dstRes) {
+    const headers = srcRes.headers.raw()
+    const buffer = await srcRes.buffer()
 
     // remove content-length and content-encoding
     // node-fetch decompresses compressed responses
     // so these headers are usually wrong
     delete headers['content-length']
     delete headers['content-encoding']
-
     dstRes.writeHead(srcRes.status, srcRes.statusText, headers)
-
-    if (srcRes.body instanceof nodeStream.Stream) {
-      srcRes.body.on('end', () => {
-        dstRes.end()
-        if (callback) {
-          callback()
-        }
-      })
-      srcRes.body.on('error', (error) => {
-        this.logDebugError(error)
-        dstRes.end() // too late to return a 500 unfortunately
-        if (callback) {
-          callback()
-        }
-      })
-      srcRes.body.pipe(dstRes, {end: false})
-    } else if (typeof srcRes.body === 'string') {
-      dstRes.end(srcRes.body)
-      if (callback) {
-        callback()
-      }
-    } else {
-      srcRes.buffer().then(buffer => {
-        dstRes.write(buffer)
-        dstRes.end()
-        if (callback) {
-          callback()
-        }
-      })
-    }
+    dstRes.write(buffer)
+    dstRes.end()
   }
 
   load (workerScript, context) {

--- a/lib/runtime/__tests__/fetch.test.js
+++ b/lib/runtime/__tests__/fetch.test.js
@@ -1,5 +1,5 @@
 const fetchMock = require('jest-fetch-mock')
-const fetch = require('node-fetch')
+const fetch = require('@dollarshaveclub/node-fetch')
 
 // Make fetch.Request, fetch.Response, etc etc available
 // on the mock. There's probably a better way.
@@ -7,7 +7,7 @@ Object.keys(fetch).forEach(key => {
   fetchMock[key] = fetch[key]
 })
 
-jest.doMock('node-fetch', () => {
+jest.doMock('@dollarshaveclub/node-fetch', () => {
   // Make fetch.Request, fetch.Response, etc etc available
   // on the mock. There's probably a better way.
   Object.keys(fetch).forEach(key => {
@@ -18,8 +18,6 @@ jest.doMock('node-fetch', () => {
 })
 
 const { Request, Response, Headers, freezeHeaders } = require('../fetch')
-const { ReadableStream, TransformStream } = require('../stream')
-const nodeStream = require('stream')
 
 const shimFetch = require('../fetch').fetch
 
@@ -52,10 +50,10 @@ describe('fetch', () => {
     expect(() => { cloned.headers.set('test', 'test') }).not.toThrowError()
   })
 
-  test('Response has redirect', () => {
+  test('Response has redirect', async () => {
     const redirect = Response.redirect('https://google.com', 301)
 
-    expect(redirect.body).toEqual('')
+    expect(await redirect.text()).toEqual('')
     expect(redirect.status).toEqual(301)
     expect(redirect.headers.get('Location')).toEqual('https://google.com')
   })
@@ -65,13 +63,20 @@ describe('fetch', () => {
     expect(redirect.status).toEqual(302)
   })
 
-  test('Response clone returns new response', () => {
+  test('Response clone returns new response', async () => {
     const someResponse = Response.redirect('https://google.com', 302)
     const cloned = someResponse.clone()
+
+    const expectBody = await someResponse.buffer()
+    const cloneBody = await cloned.buffer()
+
     // not same object
     expect(cloned).not.toBe(someResponse)
+
     // but same fields
-    expect(cloned).toEqual(someResponse)
+    expect(cloned.status).toEqual(someResponse.status)
+    expect(cloneBody).toEqual(expectBody)
+
     // is same type
     expect(cloned.constructor).toEqual(someResponse.constructor)
   })
@@ -87,22 +92,6 @@ describe('fetch', () => {
     const someResponse = Response.redirect('https://google.com', 302)
     const cloned = someResponse.clone()
     expect(() => { cloned.headers.set('test', 'test') }).not.toThrowError()
-  })
-
-  test('Response wraps ReadableStream', () => {
-    const res = new Response(new ReadableStream())
-    expect(res.body).toBeInstanceOf(nodeStream.Stream)
-  })
-
-  test('Response throws on write of non-TypedArray on stream', (done) => {
-    const { readable, writable } = new TransformStream()
-    const writer = writable.getWriter()
-    writer.write(16).then(() => writer.close())
-    const res = new Response(readable)
-    res.body.on('error', (error) => {
-      expect(error).toBeInstanceOf(TypeError)
-      done()
-    })
   })
 
   test('fetch freezes response headers', async () => {

--- a/lib/runtime/cache/__tests__/cache.test.js
+++ b/lib/runtime/cache/__tests__/cache.test.js
@@ -1,6 +1,18 @@
 const CacheFactory = require('../cache')
 const fetch = require('../../fetch')
 
+const compareResponses = async (expected, actual) => {
+  const expectBody = await expected.buffer()
+  const actualBody = await actual.buffer()
+
+  // not same object
+  expect(expected).not.toBe(actual)
+
+  // but same fields
+  expect(expected.status).toEqual(actual.status)
+  expect(expectBody).toEqual(actualBody)
+}
+
 describe('cache', () => {
   test('cache factory returns a cache', () => {
     const caches = new CacheFactory(false)
@@ -11,7 +23,7 @@ describe('cache', () => {
     expect(cacheOpen).toBeInstanceOf(CacheFactory._Cache)
   })
 
-  test('cache basic put / match / delete', async () => {
+  test('cache basic put / match / delete', async (done) => {
     const caches = new CacheFactory(false)
     const cache = caches.default
     const req = new fetch.Request('https://www.dollarshaveclub.com/test')
@@ -23,16 +35,17 @@ describe('cache', () => {
     expectedCachedRes.headers.set('cf-cache-status', 'HIT')
 
     expect(put).toBe(undefined)
-    expect(cached).toEqual(expectedCachedRes)
+    await compareResponses(expectedCachedRes, cached)
 
     const deleted = await cache.delete(req)
     cached = await cache.match(req)
 
     expect(deleted).toEqual(true)
     expect(cached).toBe(undefined)
+    done()
   })
 
-  test('cache clones matched response', async () => {
+  test('cache clones matched response', async (done) => {
     const caches = new CacheFactory(false)
     const cache = caches.default
     const req = new fetch.Request('https://www.dollarshaveclub.com/test')
@@ -42,15 +55,19 @@ describe('cache', () => {
     const cached1 = await cache.match(req)
     const cached2 = await cache.match(req)
 
-    const expectedCachedRes = res.clone()
-    expectedCachedRes.headers.set('cf-cache-status', 'HIT')
+    const expectedCachedRes1 = res.clone()
+    const expectedCachedRes2 = res.clone()
+    expectedCachedRes1.headers.set('cf-cache-status', 'HIT')
+    expectedCachedRes2.headers.set('cf-cache-status', 'HIT')
 
-    expect(cached1).toEqual(expectedCachedRes)
-    expect(cached2).toEqual(expectedCachedRes)
+    await compareResponses(expectedCachedRes1, cached1)
+    await compareResponses(expectedCachedRes2, cached2)
+
     expect(cached2).not.toBe(cached1)
+    done()
   })
 
-  test('cache expires after max-age', async () => {
+  test('cache expires after max-age', async (done) => {
     const caches = new CacheFactory(false)
     const cache = caches.default
     const req = new fetch.Request('https://www.dollarshaveclub.com/test')
@@ -61,24 +78,26 @@ describe('cache', () => {
     const expectedCachedRes = res.clone()
     expectedCachedRes.headers.set('cf-cache-status', 'HIT')
 
-    const checkCache = async () => {
+    const checkCache = async (done) => {
+      const expected = res.clone()
       const cached = await cache.match(req)
-      expect(cached).toEqual(expectedCachedRes)
+      await compareResponses(expected, cached)
     }
 
-    checkCache()
+    await checkCache()
 
     for (let then = Date.now() + 500; then > Date.now();); // Spin for .5 seconds
 
-    checkCache()
+    await checkCache()
 
     for (let then = Date.now() + 510; then > Date.now();); // Spin for .51 seconds
 
     const cached = await cache.match(req)
     expect(cached).toBe(undefined)
+    done()
   })
 
-  test('cache expires after s-maxage', async () => {
+  test('cache expires after s-maxage', async (done) => {
     const caches = new CacheFactory(false)
     const cache = caches.default
     const req = new fetch.Request('https://www.dollarshaveclub.com/test')
@@ -91,15 +110,16 @@ describe('cache', () => {
     expectedCachedRes.headers.set('cf-cache-status', 'HIT')
 
     expect(put).toBe(undefined)
-    expect(cached).toEqual(expectedCachedRes)
+    await compareResponses(expectedCachedRes, cached)
 
     for (let then = Date.now() + 2100; then > Date.now();); // Spin for 2.1 seconds
 
     cached = await cache.match(req)
     expect(cached).toBe(undefined)
+    done()
   })
 
-  test('cache does not cache private responses', async () => {
+  test('cache does not cache private responses', async (done) => {
     const caches = new CacheFactory(false)
     const cache = caches.default
 
@@ -111,9 +131,10 @@ describe('cache', () => {
 
     const cached = await cache.match(req)
     expect(cached).toEqual(undefined)
+    done()
   })
 
-  test('cache does not cache no-store responses', async () => {
+  test('cache does not cache no-store responses', async (done) => {
     const caches = new CacheFactory(false)
     const cache = caches.default
 
@@ -125,9 +146,10 @@ describe('cache', () => {
 
     const cached = await cache.match(req)
     expect(cached).toEqual(undefined)
+    done()
   })
 
-  test('cache does not cache no-cache responses', async () => {
+  test('cache does not cache no-cache responses', async (done) => {
     const caches = new CacheFactory(false)
     const cache = caches.default
 
@@ -139,9 +161,10 @@ describe('cache', () => {
 
     const cached = await cache.match(req)
     expect(cached).toEqual(undefined)
+    done()
   })
 
-  test('cache does not cache set-cookie responses', async () => {
+  test('cache does not cache set-cookie responses', async (done) => {
     const caches = new CacheFactory(false)
     const cache = caches.default
 
@@ -153,9 +176,10 @@ describe('cache', () => {
 
     const cached = await cache.match(req)
     expect(cached).toEqual(undefined)
+    done()
   })
 
-  test('cache caches set-cookie responses with private=set-cookie cache control', async () => {
+  test('cache caches set-cookie responses with private=set-cookie cache control', async (done) => {
     const caches = new CacheFactory(false)
     const cache = caches.default
 
@@ -171,6 +195,7 @@ describe('cache', () => {
     expectedCachedRes.headers.set('cf-cache-status', 'HIT')
     expectedCachedRes.headers.delete('set-cookie')
 
-    expect(cached).toEqual(expectedCachedRes)
+    await compareResponses(expectedCachedRes, cached)
+    done()
   })
 })

--- a/lib/runtime/fetch.js
+++ b/lib/runtime/fetch.js
@@ -1,28 +1,23 @@
-const fetch = require('node-fetch')
+const fetch = require('@dollarshaveclub/node-fetch')
 const Request = fetch.Request
 const Response = fetch.Response
 const Headers = fetch.Headers
-const nodeStream = require('stream')
-const streams = require('@mattiasbuelens/web-streams-polyfill/ponyfill')
-const util = require('util')
 
 async function fetchShim (...args) {
-  const init = args[1] || {}
-  const headers = args[0].headers || init.headers || {}
-  // Cloudflare strips the Host header
-  if (headers instanceof Headers) {
-    headers.delete('Host')
-  } else {
-    Object.keys(headers).forEach(key => {
-      if (key.toLowerCase() === 'host') {
-        delete headers[key]
-      }
-    })
-  }
+  const req = new Request(...args)
 
-  const resp = await fetch(...args)
-  freezeHeaders(resp.headers)
-  return resp
+  // In Cloudflare Workers, host header
+  // is ignored
+  req.headers.delete('host')
+
+  // In Cloudflare Workers, no upstream requests
+  // get chunked
+  req.headers.set('transfer-encoding', '')
+
+  const resp = await fetch(req)
+  const shim = new ShimResponse(resp)
+  freezeHeaders(shim.headers)
+  return shim
 }
 
 function freezeHeaders (headers) {
@@ -38,47 +33,6 @@ function freezeHeaders (headers) {
 class ShimResponse extends Response {
   static redirect (url, status) {
     return new ShimResponse('', {status: status || 302, headers: {Location: url}})
-  }
-
-  constructor (...args) {
-    // Copied from node-fetch's Response class
-    let body = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : null
-    const opts = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {}
-
-    // Cloudflare supports returning a web-streams ReadableStream as a response body
-    // node-fetch does not. To overcome this limitation, we push the contents
-    // into a Node Reabable stream.
-    if (body instanceof streams.ReadableStream) {
-      // Enable object mode so we can push things other than Uint8 and strings.
-      // Cloudflare supports pushing TypedArrays and ArrayBuffers.
-      // We assert the type while streaming it and then
-      // convert it to a Buffer so that it can be piped
-      // to a ServerResponse
-      var wrapper = new nodeStream.Readable({objectMode: false})
-      const doRead = (reader) => {
-        reader.read().then((res) => {
-          if (res.value) {
-            if (!util.types.isArrayBuffer(res.value) && !util.types.isTypedArray(res.value)) {
-              const error = TypeError('TransformStreams may only transport bytes, i.e. ArrayBuffers or ArrayBufferViews. Use as an arbitrary object transport is not implemented.')
-              wrapper.destroy(error)
-              return
-            }
-
-            wrapper.push(Buffer.from(res.value))
-          }
-
-          if (res.done) {
-            wrapper.push(null)
-          } else {
-            doRead(reader)
-          }
-        })
-      }
-      doRead(body.getReader())
-      body = wrapper
-    }
-
-    super(body, opts)
   }
 
   clone () {

--- a/lib/runtime/fetch.js
+++ b/lib/runtime/fetch.js
@@ -15,7 +15,7 @@ async function fetchShim (...args) {
   req.headers.set('transfer-encoding', '')
 
   const resp = await fetch(req)
-  const shim = new ShimResponse(resp)
+  const shim = new ShimResponse(resp.body, resp)
   freezeHeaders(shim.headers)
   return shim
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dollarshaveclub/cloudworker",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -170,6 +170,14 @@
         "esutils": "^2.0.2",
         "lodash": "^4.2.0",
         "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@dollarshaveclub/node-fetch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@dollarshaveclub/node-fetch/-/node-fetch-3.0.3.tgz",
+      "integrity": "sha512-m1oI1W++pKqYApohK3h6ZGhQBllyIACL74vBbdhATHTjNFeVOP8oc+cWCqLF5mtVSu6LxodyYuR16je0EN2f7w==",
+      "requires": {
+        "web-streams-polyfill": "^1.3.2"
       }
     },
     "@mattiasbuelens/web-streams-polyfill": {
@@ -5006,11 +5014,6 @@
         "lower-case": "^1.1.1"
       }
     },
-    "node-fetch": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
-      "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -7039,6 +7042,11 @@
           "dev": true
         }
       }
+    },
+    "web-streams-polyfill": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-1.3.2.tgz",
+      "integrity": "sha1-NxkkXpCSgtk5Z4JfRLzVUOnAOZU="
     },
     "webidl-conversions": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -29,13 +29,13 @@
   ],
   "homepage": "https://github.com/dollarshaveclub/cloudworker#readme",
   "dependencies": {
+    "@dollarshaveclub/node-fetch": "^3.0.3",
     "@mattiasbuelens/web-streams-polyfill": "^0.1.0",
     "arraybuffer-equal": "^1.0.4",
     "commander": "^2.19.0",
     "http-cache-semantics": "^4.0.1",
     "lru-cache": "^5.1.1",
     "moment": "^2.22.2",
-    "node-fetch": "^2.2.0",
     "text-encoding": "^0.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Use more spec compliant fetch polyfill (ReadableStream as body for `Request` and `Response`). Fixes #21.