### PR TITLE
Allow dispatching of Requests directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,26 @@ Install via NPM:
 ```sh
 npm install -g @dollarshaveclub/cloudworker
 ```
+## Package Usage
 
-## Usage
+```
+const Cloudworker = require('@dollarshaveclub/cloudworker')
+
+const simpleScript = `addEventListener('fetch', event => {
+  event.respondWith(new Response('hello', {status: 200}))
+})`
+
+const req = new Cloudworker.Request('https://myfancywebsite.com/someurl')
+const cw = new Cloudworker(simpleScript)
+cw.dispatch(req).then((res) => {
+  console.log("Response Status: ", res.status)
+  res.text().then((body) =>{
+    console.log("Response Body: ", body)
+  })
+})
+```
+
+## CLI Usage
 
 ```sh
 Usage: cloudworker [options] <file>

--- a/index.js
+++ b/index.js
@@ -1,1 +1,3 @@
 module.exports = require('./lib/cloudworker')
+module.exports.Request = require('./lib/runtime').Request
+module.exports.Response = require('./lib/runtime').Response

--- a/lib/__tests__/cloudworker.test.js
+++ b/lib/__tests__/cloudworker.test.js
@@ -6,11 +6,16 @@ const simpleScript = `addEventListener('fetch', event => {
 })
 `
 describe('cloudworker', () => {
+  test('throws on invalid script', async () => {
+    expect(() => { new Cloudworker() }).toThrow(new TypeError('worker script must be a string')) // eslint-disable-line no-new
+    expect(() => { new Cloudworker(12) }).toThrow(new TypeError('worker script must be a string')) // eslint-disable-line no-new
+  })
+
   test('log does nothing if debug is false', async () => {
     const cw = new Cloudworker(simpleScript)
     global.console = {error: jest.fn(), log: jest.fn()}
-    cw.logDebug('test')
-    cw.logDebugError('test')
+    cw._logDebug('test')
+    cw._logDebugError('test')
     expect(console.error).not.toBeCalled()
     expect(console.log).not.toBeCalled()
   })
@@ -18,8 +23,8 @@ describe('cloudworker', () => {
   test('log if debug is true', () => {
     const cw = new Cloudworker(simpleScript, {debug: true})
     global.console = {error: jest.fn(), log: jest.fn()}
-    cw.logDebug('test')
-    cw.logDebugError('test')
+    cw._logDebug('test')
+    cw._logDebugError('test')
     expect(console.error).toBeCalled()
     expect(console.log).toBeCalled()
   })
@@ -28,7 +33,7 @@ describe('cloudworker', () => {
     const cw = new Cloudworker(simpleScript)
     const srcRes = new runtime.Response('world', {headers: {'content-length': '100', 'content-encoding': '200', other: 'value'}})
     const dstRes = httpMocks.createResponse()
-    await cw.pipe(srcRes, dstRes)
+    await cw._pipe(srcRes, dstRes)
     expect(dstRes.getHeader('other')).toEqual(['value'])
     expect(dstRes.getHeader('content-length')).toEqual(undefined)
     expect(dstRes.getHeader('content-encoding')).toEqual(undefined)
@@ -48,7 +53,7 @@ describe('cloudworker', () => {
 
     const srcRes = new runtime.Response('world', {headers: headers})
     const dstRes = httpMocks.createResponse()
-    await cw.pipe(srcRes, dstRes)
+    await cw._pipe(srcRes, dstRes)
     expect(dstRes.getHeader('Set-Cookie')).toEqual([cookie1, cookie2])
   })
 
@@ -56,7 +61,7 @@ describe('cloudworker', () => {
     const cw = new Cloudworker(simpleScript)
     const srcRes = new runtime.Response('world')
     const dstRes = httpMocks.createResponse()
-    await cw.pipe(srcRes, dstRes)
+    await cw._pipe(srcRes, dstRes)
     expect(dstRes._getBuffer()).toEqual(Buffer.from('world', 'utf8'))
   })
 
@@ -69,7 +74,7 @@ describe('cloudworker', () => {
     dstRes.on('end', () => {
       expect(dstRes._getBuffer().compare(want)).toEqual(0)
     })
-    await cw.pipe(srcRes, dstRes)
+    await cw._pipe(srcRes, dstRes)
   })
 
   test('pipe pipes stream body', done => {
@@ -86,6 +91,16 @@ describe('cloudworker', () => {
       done()
     })
 
-    cw.pipe(srcRes, dstRes)
+    cw._pipe(srcRes, dstRes)
+  })
+
+  test('dispatch returns a response', async done => {
+    const cw = new Cloudworker(simpleScript)
+    const req = new runtime.Request('https://myfancywebsite.com/someurl')
+    const res = await cw.dispatch(req)
+    const body = await res.text()
+    expect(res.status).toEqual(200)
+    expect(body).toEqual('hello')
+    done()
   })
 })

--- a/lib/cloudworker.js
+++ b/lib/cloudworker.js
@@ -8,6 +8,10 @@ const CacheFactory = require('./runtime/cache/cache')
 
 class Cloudworker {
   constructor (workerScript, {debug = false, bindings = {}, enableCache = false} = {}) {
+    if (!workerScript || typeof workerScript !== 'string') {
+      throw new TypeError('worker script must be a string')
+    }
+
     this.debug = debug
     this.dispatcher = new EventEmitter()
     const eventListener = (eventType, handler) => {
@@ -20,15 +24,36 @@ class Cloudworker {
     const cacheFactory = enableCache ? new CacheFactory() : new StubCacheFactory()
     this.context = new runtime.Context(eventListener, cacheFactory, bindings)
 
-    this.load(workerScript, this.context)
+    this._load(workerScript, this.context)
+  }
+
+  async dispatch (request) {
+    if (!(request instanceof runtime.Request)) {
+      throw new TypeError('argument must be a Request')
+    }
+
+    runtime.freezeHeaders(request.headers)
+    const promise = new Promise((resolve, reject) => {
+      const respondWith = async (callBackResp) => {
+        resolve(await callBackResp)
+      }
+
+      const error = async (error) => {
+        reject(error)
+      }
+
+      const event = new runtime.FetchEvent(request, respondWith, () => {}, error)
+      this.dispatcher.emit('fetch', event)
+    })
+    return promise
   }
 
   listen (...args) {
-    const server = http.createServer(this.handle.bind(this))
+    const server = http.createServer(this._handle.bind(this))
     return server.listen(...args)
   }
 
-  async handle (req, res) {
+  async _handle (req, res) {
     const start = new Date()
 
     var url = 'http://' + req.headers['host'] + req.url
@@ -51,14 +76,14 @@ class Cloudworker {
     const respondWith = async (callBackResp) => {
       const log = () => {
         const end = new Date()
-        this.logRequest(req, res, start, end)
+        this._logRequest(req, res, start, end)
       }
 
       try {
         callBackResp = await callBackResp
-        await this.pipe(callBackResp, res)
+        await this._pipe(callBackResp, res)
       } catch (error) {
-        this.logDebugError(error)
+        this._logDebugError(error)
         res.statusCode = 500
         res.end()
       } finally {
@@ -67,12 +92,12 @@ class Cloudworker {
     }
 
     const error = async (error) => {
-      this.logDebugError(error)
+      this._logDebugError(error)
       res.statusCode = 500
       res.end()
 
       const end = new Date()
-      this.logRequest(req, res, start, end)
+      this._logRequest(req, res, start, end)
     }
 
     const event = new runtime.FetchEvent(request, respondWith, () => {}, error)
@@ -82,11 +107,11 @@ class Cloudworker {
     } catch (error) {
       res.statusCode = 500
       res.end()
-      this.logDebugError(error)
+      this._logDebugError(error)
     }
   }
 
-  async pipe (srcRes, dstRes) {
+  async _pipe (srcRes, dstRes) {
     const headers = srcRes.headers.raw()
     const buffer = await srcRes.buffer()
 
@@ -100,25 +125,25 @@ class Cloudworker {
     dstRes.end()
   }
 
-  load (workerScript, context) {
+  _load (workerScript, context) {
     vm.createContext(context)
     vm.runInContext(workerScript, context)
   }
 
-  logRequest (request, response, start, end) {
+  _logRequest (request, response, start, end) {
     const duration = (end - start) / 1000 // convert from milliseconds to seconds
     const date = moment(start).format('DD/MMM/Y:HH:mm:ss ZZ')
     const targetHost = request.headers['host'] || '-'
     const client = request.headers['x-forwarded-for'] || request.connection.remoteAddress
-    this.logDebug(`${client} - - [${date}] ${targetHost} "${request.method} ${request.url} HTTP/${request.httpVersion}" ${response.statusCode} ${duration}`)
+    this._logDebug(`${client} - - [${date}] ${targetHost} "${request.method} ${request.url} HTTP/${request.httpVersion}" ${response.statusCode} ${duration}`)
   }
 
-  logDebugError (str) {
+  _logDebugError (str) {
     if (!this.debug) return
     console.error(str)
   }
 
-  logDebug (str) {
+  _logDebug (str) {
     if (!this.debug) return
     console.log(str)
   }


### PR DESCRIPTION
Add support for dispatching of requests directly using a `dispatch` method on instances of Cloudworker. This should solve the use-case documented in #26.