### PR TITLE
Don't add Transfer-Encoding Header if fetch request has no body

### DIFF
--- a/lib/__tests__/cloudworker-e2e.test.js
+++ b/lib/__tests__/cloudworker-e2e.test.js
@@ -211,4 +211,13 @@ describe('cloudworker-e2e', async () => {
     await upstream.close()
     cb()
   })
+
+  test('github issue 33', async (cb) => {
+    const script = utils.read(path.join(__dirname, 'fixtures/github-issue-33.js'))
+    const server = new Cloudworker(script).listen(8080)
+    const res = await axios.get('http://localhost:8080', defaultAxiosOpts)
+    expect(res.status).toEqual(200)
+    await server.close()
+    cb()
+  })
 })

--- a/lib/__tests__/fixtures/github-issue-33.js
+++ b/lib/__tests__/fixtures/github-issue-33.js
@@ -1,0 +1,30 @@
+addEventListener("fetch", event => {
+  event.respondWith(fetchAndStream(event.request))
+})
+
+async function fetchAndStream(request) {
+  // Fetch from origin server.
+  let response = await fetch("http://www.google.com/robots.txt")
+
+  // Create an identity TransformStream (a.k.a. a pipe).
+  // The readable side will become our new response body.
+  let { readable, writable } = new TransformStream()
+
+  // Start pumping the body. NOTE: No await!
+  streamBody(response.body, writable)
+
+  // ... and deliver our Response while that's running.
+  return new Response(readable, response)
+}
+
+async function streamBody(readable, writable) {
+  let reader = readable.getReader()
+  let writer = writable.getWriter()
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    await writer.write(value)
+  }
+  writer.close()
+}

--- a/lib/runtime/fetch.js
+++ b/lib/runtime/fetch.js
@@ -12,7 +12,9 @@ async function fetchShim (...args) {
 
   // In Cloudflare Workers, no upstream requests
   // get chunked
-  req.headers.set('transfer-encoding', '')
+  if (req.body) {
+    req.headers.set('transfer-encoding', '')
+  }
 
   const resp = await fetch(req)
   const shim = new ShimResponse(resp.body, resp)


### PR DESCRIPTION
Only add the empty transfer-encoding header to fetch requests when request has body.

Fixes #33 