### PR TITLE
base64 encoding and decoding polyfill for Web Global APIs

### DIFF
--- a/lib/__tests__/cloudworker-e2e.test.js
+++ b/lib/__tests__/cloudworker-e2e.test.js
@@ -211,4 +211,32 @@ describe('cloudworker-e2e', async () => {
     await upstream.close()
     cb()
   })
+
+  test('simple decode base64', async (cb) => {
+    const script = `
+      addEventListener('fetch', event => {
+        event.respondWith(new Response(atob('SGVsbG8gV29ybGQh'), {status: 200}))
+      })
+    `
+    const server = new Cloudworker(script).listen(8080)
+    const res = await axios.get('http://localhost:8080', defaultAxiosOpts)
+    expect(res.status).toEqual(200)
+    expect(res.data).toEqual('Hello World!')
+    await server.close()
+    cb()
+  })
+
+  test('simple encode base64', async (cb) => {
+    const script = `
+      addEventListener('fetch', event => {
+        event.respondWith(new Response(btoa('Hello World!'), {status: 200}))
+      })
+    `
+    const server = new Cloudworker(script).listen(8080)
+    const res = await axios.get('http://localhost:8080', defaultAxiosOpts)
+    expect(res.status).toEqual(200)
+    expect(res.data).toEqual('SGVsbG8gV29ybGQh')
+    await server.close()
+    cb()
+  })
 })

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -2,6 +2,7 @@ const { Request, Response, fetch, Headers, freezeHeaders } = require('./runtime/
 const { URL } = require('./runtime/url')
 const { ReadableStream, WritableStream, TransformStream } = require('./runtime/stream')
 const { FetchEvent } = require('./runtime/fetch-event')
+const { atob, btoa } = require('./runtime/base64')
 
 class Context {
   constructor (addEventListener, cacheFactory, bindings = {}) {
@@ -18,6 +19,8 @@ class Context {
     this.TransformStream = TransformStream
     this.FetchEvent = FetchEvent
     this.caches = cacheFactory
+    this.atob = atob
+    this.btoa = btoa
   }
 }
 
@@ -33,4 +36,6 @@ module.exports = {
   WritableStream,
   TransformStream,
   URL,
+  atob,
+  btoa,
 }

--- a/lib/runtime/base64.js
+++ b/lib/runtime/base64.js
@@ -1,0 +1,4 @@
+const b2a = require('b2a')
+
+module.exports.atob = b2a.atob
+module.exports.btoa = b2a.btoa

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "http-cache-semantics": "^4.0.1",
     "lru-cache": "^5.1.1",
     "moment": "^2.22.2",
-    "text-encoding": "^0.7.0"
+    "text-encoding": "^0.7.0",
+    "b2a": "^1.0.10"
   },
   "devDependencies": {
     "axios": "^0.18.0",


### PR DESCRIPTION
This pull request includes the exposure of the 2 methods `atob` and `btoa` that are available in the Web Global APIs, for working with base64 encoding.