### PR TITLE
Hot-reloading worker scripts - added --watch flag to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Options:
   -s, --set [variabe.key=value]  Binds variable to a local implementation of Workers KV and sets key to value (default: [])
   -w, --wasm [variable=path]     Binds variable to wasm located at path (default: [])
   -c, --enable-cache             Enables cache <BETA>
+  -r, --watch                    Watch the worker script and restart the worker when changes are detected
   -h, --help                     output usage information
 ```
 

--- a/bin/cloudworker.js
+++ b/bin/cloudworker.js
@@ -2,6 +2,7 @@
 
 const program = require('commander')
 const Cloudworker = require('..')
+const fs = require('fs')
 const path = require('path')
 const utils = require('../lib/utils')
 const wasmLoader = require('../lib/wasm')
@@ -20,6 +21,7 @@ program
   .option('-s, --set [variabe.key=value]', 'Binds variable to a local implementation of Workers KV and sets key to value', collect, [])
   .option('-w, --wasm [variable=path]', 'Binds variable to wasm located at path', collect, [])
   .option('-c, --enable-cache', 'Enables cache <BETA>', false)
+  .option('-r, --watch', 'Watch the worker script and restart the worker when changes are detected', false)
   .action(f => { file = f })
   .parse(process.argv)
 
@@ -49,15 +51,37 @@ function run (file, wasmBindings) {
   console.log(`Listening on ${program.port}`)
 
   let stopping = false
+  let reloading = false
+
+  if (program.watch) {
+    fs.watchFile(fullpath, () => {
+      reloading = true
+      console.log('Changes to the worker script detected - reloading...')
+
+      server.close(() => {
+        if (stopping) return
+
+        reloading = false
+        console.log('Successfully reloaded!')
+
+        server = new Cloudworker(utils.read(fullpath), opts).listen(program.port)
+      })
+    })
+  }
+
   function shutdown () {
     if (stopping) return
 
     stopping = true
     console.log('\nShutting down...')
-    server.close(() => {
-      console.log('Goodbye!')
-      process.exit(0)
-    })
+    server.close(terminate)
+
+    if (reloading) server.on('close', terminate)
+  }
+
+  function terminate () {
+    console.log('Goodbye!')
+    process.exit(0)
   }
 
   process.on('SIGINT', () => {

--- a/bin/cloudworker.js
+++ b/bin/cloudworker.js
@@ -46,7 +46,7 @@ function run (file, wasmBindings) {
   Object.assign(bindings, wasmBindings)
 
   const opts = {debug: program.debug, enableCache: program.enableCache, bindings: bindings}
-  const server = new Cloudworker(script, opts).listen(program.port)
+  let server = new Cloudworker(script, opts).listen(program.port)
 
   console.log(`Listening on ${program.port}`)
 


### PR DESCRIPTION
I have added a "watch" flag to the CLI which will allow hot-reloading of the worker script.

This feature will watch the worker script using fs.watchFile and automatically restart the Cloudworker when a change is detected to the worker script.

This feature can be used by running the following command:

`cloudworker --watch example.js
`

This is particularly useful when creating larger worker systems with such tools as Webpack as the user could run Webpack with the watch flag at the same time (as we do in our team).

For example;

`
cloudworker --watch dist/main.js &
webpack --watch src/main.js
`


