### PR TITLE
Context Properties Test

### DIFF
--- a/lib/__tests__/runtime.test.js
+++ b/lib/__tests__/runtime.test.js
@@ -7,4 +7,30 @@ describe('runtime', () => {
     const context = new runtime.Context(() => {}, dummyFactory, {fetch: someMockFetch})
     expect(context.fetch).toBe(someMockFetch)
   })
+
+  test('context has expected properties', async () => {
+    const expected = [
+      'console',
+      'addEventListener',
+      'fetch',
+      'Request',
+      'Response',
+      'Headers',
+      'URL',
+      'ReadableStream',
+      'WritableStream',
+      'TransformStream',
+      'FetchEvent',
+      'caches',
+      'crypto',
+      'TextDecoder',
+      'TextEncoder',
+      'atob',
+      'btoa',
+    ].sort()
+
+    const dummyFactory = Symbol('dummy factory')
+    const got = Object.getOwnPropertyNames(new runtime.Context(() => {}, dummyFactory)).sort()
+    expect(got).toEqual(expected)
+  })
 })


### PR DESCRIPTION
Add test to ensure context has expected (and properly spelled) properties. This will help catch issues like #45 by requiring that test to be updated when new properties are added. 