### PR TITLE
Patched URL in Cache

### DIFF
--- a/lib/runtime/cache/cloudflareCachePolicy.js
+++ b/lib/runtime/cache/cloudflareCachePolicy.js
@@ -1,4 +1,5 @@
 const CachePolicy = require('http-cache-semantics')
+const {URL} = require('../url')
 const REQ_METHOD = Symbol('REQ_METHOD')
 
 class CloudflareCachePolicy extends CachePolicy {


### PR DESCRIPTION
Cache was not working correctly (throwing an error as there was no URL constructor).

This should be patched with this commit.