### PR TITLE
Better match Cloudflare behavior of cf property

### DIFF
--- a/lib/cloudworker.js
+++ b/lib/cloudworker.js
@@ -32,6 +32,7 @@ class Cloudworker {
       throw new TypeError('argument must be a Request')
     }
 
+    runtime.bindCfProperty(request)
     runtime.freezeHeaders(request.headers)
     const promise = new Promise((resolve, reject) => {
       const respondWith = async (callBackResp) => {
@@ -73,6 +74,7 @@ class Cloudworker {
     }
 
     const request = new runtime.Request(url, {headers: req.headers, body: body, method: req.method})
+    runtime.bindCfProperty(request)
     request.headers.set('CF-Connecting-IP', req.connection.remoteAddress)
     runtime.freezeHeaders(request.headers)
 

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -1,4 +1,4 @@
-const { Request, Response, fetch, Headers, freezeHeaders } = require('./runtime/fetch')
+const { Request, Response, fetch, Headers, freezeHeaders, bindCfProperty } = require('./runtime/fetch')
 const { URL } = require('./runtime/url')
 const { ReadableStream, WritableStream, TransformStream } = require('./runtime/stream')
 const { FetchEvent } = require('./runtime/fetch-event')
@@ -34,6 +34,7 @@ module.exports = {
   fetch,
   FetchEvent,
   freezeHeaders,
+  bindCfProperty,
   Headers,
   Request,
   Response,

--- a/lib/runtime/__tests__/fetch.test.js
+++ b/lib/runtime/__tests__/fetch.test.js
@@ -17,7 +17,7 @@ jest.doMock('@dollarshaveclub/node-fetch', () => {
   return fetchMock
 })
 
-const { Request, Response, Headers, freezeHeaders } = require('../fetch')
+const { Request, Response, Headers, freezeHeaders, bindCfProperty } = require('../fetch')
 
 const shimFetch = require('../fetch').fetch
 
@@ -132,11 +132,22 @@ describe('fetch', () => {
     expect(new Headers(headers).get('host')).toBeNull()
   })
 
-  test('Request contains cf property with dummy values', () => {
+  test('bind cf property', () => {
     const someRequest = new Request('https://google.com')
+    bindCfProperty(someRequest)
     expect(someRequest.cf.tlsVersion).toEqual('TLSv1.2')
     expect(someRequest.cf.tlsCipher).toEqual('ECDHE-ECDSA-CHACHA20-POLY1305')
     expect(someRequest.cf.country).toEqual('US')
     expect(someRequest.cf.colo).toEqual('LAX')
+  })
+
+  test('cf property preserved across clone', () => {
+    const someRequest = new Request('https://google.com')
+    bindCfProperty(someRequest)
+    const cloned = someRequest.clone()
+    expect(cloned.cf.tlsVersion).toEqual('TLSv1.2')
+    expect(cloned.cf.tlsCipher).toEqual('ECDHE-ECDSA-CHACHA20-POLY1305')
+    expect(cloned.cf.country).toEqual('US')
+    expect(cloned.cf.colo).toEqual('LAX')
   })
 })

--- a/lib/runtime/fetch.js
+++ b/lib/runtime/fetch.js
@@ -67,24 +67,30 @@ class ShimRequest extends Request {
     if (this.headers.frozen) {
       freezeHeaders(req.headers)
     }
+    if (this.cf) {
+      bindCfProperty(req)
+    }
 
     return req
   }
 }
 
-Object.defineProperty(ShimRequest.prototype, 'cf', {
-  value: {
-    tlsVersion: 'TLSv1.2',
-    tlsCipher: 'ECDHE-ECDSA-CHACHA20-POLY1305',
-    country: 'US',
-    colo: 'LAX',
-  },
-  writable: false,
-  enumerable: false,
-})
+function bindCfProperty (req) {
+  Object.defineProperty(req, 'cf', {
+    value: {
+      tlsVersion: 'TLSv1.2',
+      tlsCipher: 'ECDHE-ECDSA-CHACHA20-POLY1305',
+      country: 'US',
+      colo: 'LAX',
+    },
+    writable: false,
+    enumerable: false,
+  })
+}
 
 module.exports.fetch = fetchShim
 module.exports.Request = ShimRequest
 module.exports.Response = ShimResponse
 module.exports.Headers = Headers
 module.exports.freezeHeaders = freezeHeaders
+module.exports.bindCfProperty = bindCfProperty


### PR DESCRIPTION
The `cf` property should only be on the original request and any requests cloned from it. This PR changes cloudworker to match that. 