### PR TITLE
Add UrlSearchParams polyfill to Cloudworker

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,3 +17,4 @@ module.exports.TextEncoder = runtime.TextEncoder
 module.exports.atob = runtime.atob
 module.exports.btoa = runtime.btoa
 module.exports.KeyValueStore = kv.KeyValueStore
+module.exports.URLSearchParams = runtime.URLSearchParams

--- a/lib/__tests__/cloudworker-e2e.test.js
+++ b/lib/__tests__/cloudworker-e2e.test.js
@@ -258,6 +258,25 @@ describe('cloudworker-e2e', async () => {
     cb()
   })
 
+  test('URLSearchParams', async cb => {
+    const script = `
+      addEventListener('fetch', event => {
+        try {
+          const search = new URLSearchParams({ id: 1, from: 'home' })
+          event.respondWith(new Response(search.toString(), {status: 200}))
+        } catch (err) {
+          console.log(err)
+        }
+      })
+    `
+    const server = new Cloudworker(script).listen(8080)
+    const res = await axios.get('http://localhost:8080', defaultAxiosOpts)
+    expect(res.status).toEqual(200)
+    expect(res.data).toEqual('id=1&from=home')
+    await server.close()
+    cb()
+  })
+
   test('github issue 41', async cb => {
     const script = `
       addEventListener('fetch', async event => {

--- a/lib/__tests__/runtime.test.js
+++ b/lib/__tests__/runtime.test.js
@@ -31,6 +31,7 @@ describe('runtime', () => {
       'TextEncoder',
       'atob',
       'btoa',
+      'URLSearchParams',
     ].sort()
 
     const dummyFactory = Symbol('dummy factory')

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -5,6 +5,7 @@ const { FetchEvent } = require('./runtime/fetch-event')
 const { crypto } = require('./runtime/crypto')
 const { TextDecoder, TextEncoder } = require('./runtime/text-encoder')
 const { atob, btoa } = require('./runtime/base64')
+const { URLSearchParams } = require('./runtime/url-search-params')
 
 class Context {
   constructor (addEventListener, cacheFactory, bindings = {}) {
@@ -29,6 +30,7 @@ class Context {
     this.TextEncoder = TextEncoder
     this.atob = atob
     this.btoa = btoa
+    this.URLSearchParams = URLSearchParams
     Object.assign(this, bindings)
   }
 }
@@ -50,4 +52,5 @@ module.exports = {
   TextEncoder,
   atob,
   btoa,
+  URLSearchParams,
 }

--- a/lib/runtime/url-search-params.js
+++ b/lib/runtime/url-search-params.js
@@ -1,0 +1,2 @@
+const URLSearchParams = require('@ungap/url-search-params')
+module.exports.URLSearchParams = URLSearchParams

--- a/package-lock.json
+++ b/package-lock.json
@@ -214,6 +214,11 @@
       "resolved": "https://registry.npmjs.org/@types/whatwg-streams/-/whatwg-streams-0.0.6.tgz",
       "integrity": "sha512-O4Hat94N1RUCObqAbVUtd6EcucseqBcpfbFXzy12CYF6BQVHWR+ztDA3YPjewCmdKHYZ5VA7TZ5hq2bMyqxiBw=="
     },
+    "@ungap/url-search-params": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/url-search-params/-/url-search-params-0.1.2.tgz",
+      "integrity": "sha512-WVk5+lJ+AoNLh2sIDMhnEAgLsVQuI067hWLJCzirErH1GYiy1gs09q4+XZxYWSvdAsslKsaO4q1iXXMx2c72dA=="
+    },
     "abab": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "@dollarshaveclub/node-fetch": "^3.1.0",
     "@mattiasbuelens/web-streams-polyfill": "^0.1.0",
+    "@ungap/url-search-params": "^0.1.2",
     "arraybuffer-equal": "^1.0.4",
     "b2a": "^1.0.10",
     "commander": "^2.19.0",


### PR DESCRIPTION
Uses https://github.com/ungap/url-search-params to add a `URLSearchParams` polyfill (though technically it's a [ponyfill](https://github.com/sindresorhus/ponyfill)) that can be used inside of Cloudworker scripts.

Closes #79.