### PR TITLE
Don't close the server and reload if already reloading

### DIFF
--- a/bin/cloudworker.js
+++ b/bin/cloudworker.js
@@ -60,6 +60,9 @@ function run (file, wasmBindings) {
 
   if (program.watch) {
     fs.watchFile(fullpath, () => {
+      if(reloading) {
+        return
+      }
       reloading = true
       console.log('Changes to the worker script detected - reloading...')
 

--- a/bin/cloudworker.js
+++ b/bin/cloudworker.js
@@ -60,7 +60,7 @@ function run (file, wasmBindings) {
 
   if (program.watch) {
     fs.watchFile(fullpath, () => {
-      if(reloading) {
+      if (reloading) {
         return
       }
       reloading = true


### PR DESCRIPTION
Hi, I came across an issue with the CLI where if a watched file is edited multiple times while the server is restarting, Cloudworker tries to start multiple servers resulting in an `EADDRINUSE` error.

```
Changes to the worker script detected - reloading...
{...access logs}
Changes to the worker script detected - reloading...
{...more access logs}
Successfully reloaded!
events.js:174
      throw er; // Unhandled 'error' event
      ^

Error: listen EADDRINUSE: address already in use :::3001
    at Server.setupListenHandle [as _listen2] (net.js:1279:14)
    at listenInCluster (net.js:1327:12)
    at Server.listen (net.js:1414:7)
    at Cloudworker.listen (/Users/ricky/srv/ricky-me-cf-worker/node_modules/@dollarshaveclub/cloudworker/lib/cloudworker.js:57:19)
    at server.close (/Users/ricky/srv/ricky-me-cf-worker/node_modules/@dollarshaveclub/cloudworker/bin/cloudworker.js:72:62)
    at Server.close (net.js:1565:9)
    at Object.onceWrapper (events.js:286:20)
    at Server.emit (events.js:203:15)
    at emitCloseNT (net.js:1618:8)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

This PR adds a check whether the process of reloading has already started before closing the server. `server.close()` should only need to be called once so I don't think this should cause any other issues.

Thanks in advance.