### PR TITLE
Keep original cf property of request

### DIFF
--- a/lib/__tests__/cloudworker.test.js
+++ b/lib/__tests__/cloudworker.test.js
@@ -165,5 +165,4 @@ describe('cloudworker', () => {
     expect(res.headers.get('x-colo')).toEqual('YYZ')
     done()
   })
-
 })

--- a/lib/__tests__/cloudworker.test.js
+++ b/lib/__tests__/cloudworker.test.js
@@ -129,4 +129,41 @@ describe('cloudworker', () => {
     expect(res.headers.get('x-colo')).toEqual('LAX')
     done()
   })
+
+  test('dispatch respects existing cf property', async done => {
+    const script = `
+      addEventListener('fetch', event => {
+        const req = event.request
+        const cloned = req.clone()
+        const resp = new Response('', {
+        headers: {
+          'x-tlsVersion': cloned.cf.tlsVersion,
+          'x-tlsCipher': cloned.cf.tlsCipher,
+          'x-country': cloned.cf.country,
+          'x-colo': cloned.cf.colo,
+          }
+        })
+        event.respondWith(resp)
+      })
+    `
+    const cw = new Cloudworker(script)
+    const req = new runtime.Request('https://myfancywebsite.com/someurl')
+    Object.defineProperty(req, 'cf', {
+      value: {
+        tlsVersion: 'TLSv1.1',
+        tlsCipher: 'ACDHE-ECDSA-CHACHA20-POLY1305',
+        country: 'CA',
+        colo: 'YYZ',
+      },
+      writable: false,
+      enumerable: false,
+    })
+    const res = await cw.dispatch(req)
+    expect(res.headers.get('x-tlsversion')).toEqual('TLSv1.1')
+    expect(res.headers.get('x-tlscipher')).toEqual('ACDHE-ECDSA-CHACHA20-POLY1305')
+    expect(res.headers.get('x-country')).toEqual('CA')
+    expect(res.headers.get('x-colo')).toEqual('YYZ')
+    done()
+  })
+
 })

--- a/lib/runtime/fetch.js
+++ b/lib/runtime/fetch.js
@@ -68,7 +68,7 @@ class ShimRequest extends Request {
       freezeHeaders(req.headers)
     }
     if (this.cf) {
-      bindCfProperty(req)
+      Object.defineProperty(req, 'cf', {value: this.cf, writable: false, enumerable: false})
     }
 
     return req
@@ -76,16 +76,18 @@ class ShimRequest extends Request {
 }
 
 function bindCfProperty (req) {
-  Object.defineProperty(req, 'cf', {
-    value: {
-      tlsVersion: 'TLSv1.2',
-      tlsCipher: 'ECDHE-ECDSA-CHACHA20-POLY1305',
-      country: 'US',
-      colo: 'LAX',
-    },
-    writable: false,
-    enumerable: false,
-  })
+  if (!req.cf) {
+    Object.defineProperty(req, 'cf', {
+      value: {
+        tlsVersion: 'TLSv1.2',
+        tlsCipher: 'ECDHE-ECDSA-CHACHA20-POLY1305',
+        country: 'US',
+        colo: 'LAX',
+      },
+      writable: false,
+      enumerable: false,
+    })
+  }
 }
 
 module.exports.fetch = fetchShim


### PR DESCRIPTION
For testing purposes, it's useful to be able to override the default cf properties set in `bindCfProperty`. This will preserve any existing cf property on the request in dispatch and also after clone.

Fixes https://github.com/dollarshaveclub/cloudworker/issues/103