### PR TITLE
Adds support for Workers Sites

### DIFF
--- a/bin/cloudworker.js
+++ b/bin/cloudworker.js
@@ -21,7 +21,7 @@ program
   .option('-s, --kv-set [variable.key=value]', 'Binds variable to a local implementation of Workers KV and sets key to value', collect, [])
   .option('-f, --kv-file [variable=path]', 'Set the filepath for value peristence for the local implementation of Workers KV', collect, [])
   .option('-b, --bind [variable=value]', 'Binds variable to the value provided', collect, [])
-  .option('-c, --bind-file [variable=path]', 'Binds variable to the contents of the given file', collect, [])
+  .option('-a, --bind-file [variable=path]', 'Binds variable to the contents of the given file', collect, [])
   .option('-w, --wasm [variable=path]', 'Binds variable to wasm located at path', collect, [])
   .option('-c, --enable-cache', 'Enables cache <BETA>', false)
   .option('-r, --watch', 'Watch the worker script and restart the worker when changes are detected', false)

--- a/bin/cloudworker.js
+++ b/bin/cloudworker.js
@@ -20,6 +20,8 @@ program
   .option('-d, --debug', 'Debug', false)
   .option('-s, --kv-set [variable.key=value]', 'Binds variable to a local implementation of Workers KV and sets key to value', collect, [])
   .option('-f, --kv-file [variable=path]', 'Set the filepath for value peristence for the local implementation of Workers KV', collect, [])
+  .option('-b, --bind [variable=value]', 'Binds variable to the value provided', collect, [])
+  .option('-c, --bind-file [variable=path]', 'Binds variable to the contents of the given file', collect, [])
   .option('-w, --wasm [variable=path]', 'Binds variable to wasm located at path', collect, [])
   .option('-c, --enable-cache', 'Enables cache <BETA>', false)
   .option('-r, --watch', 'Watch the worker script and restart the worker when changes are detected', false)
@@ -44,8 +46,9 @@ function run (file, wasmBindings) {
   console.log('Starting up...')
   const fullpath = path.resolve(process.cwd(), file)
   const script = utils.read(fullpath)
-  const bindings = utils.extractKVBindings(program.kvSet.concat(program.set), program.kvFile)
-  Object.assign(bindings, wasmBindings)
+  const kvBindings = utils.extractKVBindings(program.kvSet.concat(program.set), program.kvFile)
+  const bindings = utils.extractBindings(program.bind, program.bindFile)
+  Object.assign(bindings, kvBindings, wasmBindings)
 
   // Add a warning log for deprecation
   if (program.set.length > 0) console.warn('Warning: Flag --set is now deprecated, please use --kv-set instead')

--- a/lib/__tests__/utils.test.js
+++ b/lib/__tests__/utils.test.js
@@ -35,4 +35,58 @@ describe('utils', () => {
 
     cb()
   })
+
+  test('extractKVBindings throws on invalid filepath format', async () => {
+    expect(() => { utils.extractKVBindings([], ['invalid format']) }).toThrow()
+  })
+
+  test('extractBindings throws on invalid format', async () => {
+    expect(() => { utils.extractBindings(['invalid format'], []) }).toThrow()
+  })
+
+  test('extractBindings parses properly', async () => {
+    const bindings = utils.extractBindings(['foo=bar', 'baz=qux'], [])
+    expect(bindings.foo).toEqual('bar')
+    expect(bindings.baz).toEqual('qux')
+  })
+
+  test('extractBindings allows = in value', async () => {
+    const bindings = utils.extractBindings(['foo="const bar=\'abc\';"'], [])
+    expect(bindings.foo).toEqual('"const bar=\'abc\';"')
+  })
+
+  test('extractBindings handles file as binding value', async () => {
+    const content = JSON.stringify({
+      foo: 'abc',
+      bar: 12345,
+      baz: {
+        qux: ['a', 'b', 'c', 'd'],
+        plugh: [ { id: 987 }, { id: 876 } ],
+      },
+    })
+    const path = '/tmp/__cloudworker_test.json'
+    await fs.writeFileSync(path, content)
+
+    const bindings = utils.extractBindings([], [`__DATA=${path}`])
+    expect(bindings.__DATA).toEqual(content)
+
+    await fs.unlinkSync(path)
+  })
+
+  test('extractBindings thows on invalid file format', async () => {
+    expect(() => { utils.extractBindings([], ['invalid file format']) }).toThrow()
+  })
+
+  test('extractBindings throw on nonexistent path', async () => {
+    expect(() => { utils.extractBindings([], ['foo=/tmp/__cloudworker_fake_file.json']) }).toThrow()
+  })
+
+  test('parseWasmFlags throws on invalid format', async () => {
+    expect(() => { utils.parseWasmFlags(['invalid format']) }).toThrow()
+  })
+
+  test('parseWasmFlags parses properly', async () => {
+    const bindings = utils.parseWasmFlags(['foo=bar'])
+    expect(bindings.foo).toEqual('bar')
+  })
 })

--- a/lib/__tests__/utils.test.js
+++ b/lib/__tests__/utils.test.js
@@ -40,6 +40,20 @@ describe('utils', () => {
     expect(() => { utils.extractKVBindings([], ['invalid format']) }).toThrow()
   })
 
+  test('extractKVBindings handles files and sets', async (cb) => {
+    const kv = new KeyValueStore(path.resolve('test-kv.json'))
+    kv.put('hello', 'world')
+
+    const bindings = utils.extractKVBindings(['test.this=great'], ['test=test-kv.json'])
+    const {test} = bindings
+
+    fs.unlinkSync(kv.path)
+    expect(await test.get('hello')).toEqual('world')
+    expect(await test.get('this')).toEqual('great')
+
+    cb()
+  })
+
   test('extractBindings throws on invalid format', async () => {
     expect(() => { utils.extractBindings(['invalid format'], []) }).toThrow()
   })

--- a/lib/__tests__/utils.test.js
+++ b/lib/__tests__/utils.test.js
@@ -87,11 +87,11 @@ describe('utils', () => {
     await fs.unlinkSync(path)
   })
 
-  test('extractBindings thows on invalid file format', async () => {
+  test('extractBindings throws on invalid file format', async () => {
     expect(() => { utils.extractBindings([], ['invalid file format']) }).toThrow()
   })
 
-  test('extractBindings throw on nonexistent path', async () => {
+  test('extractBindings throws on nonexistent path', async () => {
     expect(() => { utils.extractBindings([], ['foo=/tmp/__cloudworker_fake_file.json']) }).toThrow()
   })
 
@@ -102,5 +102,61 @@ describe('utils', () => {
   test('parseWasmFlags parses properly', async () => {
     const bindings = utils.parseWasmFlags(['foo=bar'])
     expect(bindings.foo).toEqual('bar')
+  })
+
+  test('generateSite throws on nonexistent path', async () => {
+    expect.assertions(1)
+    try {
+      await utils.generateSite('/not/a/real/bucket/path')
+    } catch (e) {
+      expect(e).toBeDefined()
+    }
+  })
+
+  describe('generateSite', () => {
+    const path = '/tmp/__cloudworker_test'
+    const subdir = '/subdir'
+
+    beforeAll(async () => {
+      await fs.mkdirSync(path)
+      await fs.mkdirSync(`${path}${subdir}`)
+      await fs.writeFileSync(`${path}/a`, 'a123')
+      await fs.writeFileSync(`${path}${subdir}/b`, 'b456')
+    })
+
+    test('generateSite recurses down a directory tree', async () => {
+      const { siteKvFile, siteManifest } = await utils.generateSite(path)
+
+      const siteKVFileContent = fs.readFileSync(siteKvFile.split('=')[1], 'utf-8')
+      const siteManifestContent = fs.readFileSync(siteManifest.split('=')[1], 'utf-8')
+
+      expect(siteKVFileContent).toEqual("{\n  \"a\": \"a123\",\n  \"subdir/b\": \"b456\"\n}\n") // eslint-disable-line
+      expect(siteManifestContent).toEqual(JSON.stringify({
+        'a': 'a',
+        'subdir/b': 'subdir/b',
+      }))
+    })
+
+    test('handles a path with a trailing slash the same', async () => {
+      const { siteKvFile, siteManifest } = await utils.generateSite(path)
+
+      const siteKVFileContent = fs.readFileSync(siteKvFile.split('=')[1], 'utf-8')
+      const siteManifestContent = fs.readFileSync(siteManifest.split('=')[1], 'utf-8')
+
+      const { siteKvFile: siteKvFile2, siteManifest: siteManifest2 } = await utils.generateSite(`${path}/`)
+
+      const siteKVFileContent2 = fs.readFileSync(siteKvFile2.split('=')[1], 'utf-8')
+      const siteManifestContent2 = fs.readFileSync(siteManifest2.split('=')[1], 'utf-8')
+
+      expect(siteKVFileContent2).toEqual(siteKVFileContent)
+      expect(siteManifestContent2).toEqual(siteManifestContent)
+    })
+
+    afterAll(async () => {
+      await fs.unlinkSync(`${path}/a`)
+      await fs.unlinkSync(`${path}${subdir}/b`)
+      await fs.rmdirSync(`${path}${subdir}`)
+      await fs.rmdirSync(path)
+    })
   })
 })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -32,6 +32,40 @@ module.exports.extractKVBindings = (kvSetFlags, kvFileFlags) => {
   return bindings
 }
 
+module.exports.extractBindings = (bindingFlags, bindingFileFlags) => {
+  const bindings = {}
+
+  for (const flag of bindingFlags) {
+    const comps = flag.split('=')
+    if (comps.length < 2) {
+      throw new Error('Invalid bind flag format. Expected format of [variable]=[value]')
+    }
+
+    const variable = comps[0]
+    const value = comps.slice(1).join('=')
+    bindings[variable] = value
+  }
+
+  for (const flag of bindingFileFlags) {
+    const comps = flag.split('=')
+    if (comps.length < 2) {
+      throw new Error('Invalid bind-file flag format. Expected format of [variable]=[filepath]')
+    }
+
+    const variable = comps[0]
+    const filepath = comps.slice(1).join('=')
+
+    if (!fs.existsSync(filepath)) {
+      throw new Error(`Invalid bind-file path "${filepath}"`)
+    }
+
+    const value = fs.readFileSync(filepath).toString('utf-8')
+    bindings[variable] = value
+  }
+
+  return bindings
+}
+
 const extractKVPaths = (kvFileFlags) => {
   const paths = {}
 
@@ -40,7 +74,7 @@ const extractKVPaths = (kvFileFlags) => {
   for (const flag of kvFileFlags) {
     const components = flag.split('=')
 
-    if (flag.length < 2) {
+    if (components.length < 2) {
       throw new Error('Invalid kv-file flag format. Expected format of [variable]=[value]')
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,95 +4,82 @@ module.exports.read = f => fs.readFileSync(f).toString('utf-8')
 module.exports.extractKVBindings = (kvSetFlags, kvFileFlags) => {
   const bindings = {}
 
-  const filepaths = extractKVPaths(kvFileFlags)
+  const filepaths = parseFlags('kv-file', kvFileFlags)
 
   for (const [variable, path] of Object.entries(filepaths)) {
     bindings[variable] = new KeyValueStore(path)
   }
 
-  for (const flag of kvSetFlags) {
-    const comps = flag.split('.')
-    if (comps.length < 2 || comps[1].split('=').length < 2) {
-      throw new Error('Invalid kv-set flag format. Expected format of [variable].[key]=[value]')
-    }
+  const kvStores = parseFlags('kv-set', kvSetFlags, true)
 
-    const variable = comps[0]
-    const kvFragment = comps.slice(1).join('.')
-    const kvComponents = kvFragment.split('=')
-    const key = kvComponents[0]
-    const value = kvComponents.slice(1).join('=')
-
+  for (const [variable, obj] of Object.entries(kvStores)) {
     if (!bindings[variable]) {
       bindings[variable] = new KeyValueStore(filepaths[variable])
     }
 
-    bindings[variable].put(key, value)
+    for (const [key, value] of Object.entries(obj)) {
+      bindings[variable].put(key, value)
+    }
   }
 
   return bindings
 }
 
 module.exports.extractBindings = (bindingFlags, bindingFileFlags) => {
-  const bindings = {}
+  return Object.assign(
+    {},
+    parseFlags('bind', bindingFlags),
+    parseFlags('bind-file', bindingFileFlags, false, (variable, filepath) => {
+      if (!fs.existsSync(filepath)) {
+        throw new Error(`Invalid bind-file path "${filepath}"`)
+      }
 
-  for (const flag of bindingFlags) {
-    const comps = flag.split('=')
-    if (comps.length < 2) {
-      throw new Error('Invalid bind flag format. Expected format of [variable]=[value]')
-    }
-
-    const variable = comps[0]
-    const value = comps.slice(1).join('=')
-    bindings[variable] = value
-  }
-
-  for (const flag of bindingFileFlags) {
-    const comps = flag.split('=')
-    if (comps.length < 2) {
-      throw new Error('Invalid bind-file flag format. Expected format of [variable]=[filepath]')
-    }
-
-    const variable = comps[0]
-    const filepath = comps.slice(1).join('=')
-
-    if (!fs.existsSync(filepath)) {
-      throw new Error(`Invalid bind-file path "${filepath}"`)
-    }
-
-    const value = fs.readFileSync(filepath).toString('utf-8')
-    bindings[variable] = value
-  }
-
-  return bindings
+      return fs.readFileSync(filepath).toString('utf-8')
+    })
+  )
 }
 
-const extractKVPaths = (kvFileFlags) => {
-  const paths = {}
+module.exports.parseWasmFlags = (wasmFlags) => parseFlags('wasm', wasmFlags)
 
-  if (!kvFileFlags) return paths
-
-  for (const flag of kvFileFlags) {
-    const components = flag.split('=')
-
-    if (components.length < 2) {
-      throw new Error('Invalid kv-file flag format. Expected format of [variable]=[value]')
-    }
-
-    paths[components[0]] = components[1]
-  }
-
-  return paths
-}
-
-module.exports.parseWasmFlags = (wasmFlags) => {
+/**
+ * Parse flags into bindings.
+ *
+ * @param {string} type Type of binding being parsed.
+ * @param {Array<string>} flags Command line flags to parse.
+ * @param {boolean} objectVariable Whether the variable represents an object name and key
+ * @param {Function} handleVariable Function to call for custom variable/value handling.
+ *
+ * @returns {Object} bindings The variable bindings parsed from the flags.
+ */
+function parseFlags (type, flags = [], objectVariable = false, handleVariable = null) {
   const bindings = {}
-  for (const flag of wasmFlags) {
-    const comps = flag.split('=')
-    if (comps.length !== 2) {
-      throw new Error('Invalid wasm flag format. Expected format of [variable=path]')
+
+  for (const flag of flags) {
+    if (objectVariable) {
+      const comps = flag.split('.')
+      if (comps.length < 2 || comps[1].split('=').length < 2) {
+        throw new Error(`Invalid ${type} flag format. Expected format of [variable].[key]=[value]`)
+      }
+
+      const variable = comps[0]
+      const kvFragment = comps.slice(1).join('.')
+      const kvComponents = kvFragment.split('=')
+      const key = kvComponents[0]
+      const value = kvComponents.slice(1).join('=')
+
+      bindings[variable] = Object.assign({}, bindings[variable], { [key]: value })
+    } else {
+      const comps = flag.split('=')
+      if (comps.length < 2) {
+        throw new Error(`Invalid ${type} flag format. Expected format of [variable]=[value]`)
+      }
+
+      const variable = comps[0]
+      const value = comps.slice(1).join('=')
+      if (handleVariable) bindings[variable] = handleVariable(variable, value)
+      else bindings[variable] = value
     }
-    const [variable, path] = comps
-    bindings[variable] = path
   }
+
   return bindings
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -90,25 +90,19 @@ function parseFlags (type, flags = [], objectVariable = false, handleVariable = 
 /**
  * Recursively generate a list of files in a given directory and its subdirectories.
  *
- * @param {string} path The path to the directory.
+ * @param {string} path The path to the directory. Should end with a trailing separator.
  *
  * @returns {Array<string>} List of files in the directory and its subdirectories, relative to path.
  */
 async function getDirEntries (path) {
-  const stat = promisify(fs.stat)
   const readdir = promisify(fs.readdir)
-  if (path.slice(-1) !== pathModule.sep) path += pathModule.sep
-
-  if (!await stat(path)) {
-    throw new Error(`Path does not exist: ${path}`)
-  }
 
   let entries = []
 
   const dir = await readdir(path, { withFileTypes: true })
   for (const entry of dir) {
     if (entry.isDirectory()) {
-      entries = entries.concat(await getDirEntries(`${path}${entry.name}`))
+      entries = entries.concat(await getDirEntries(`${path}${entry.name}${pathModule.sep}`))
     } else {
       entries.push(`${path}${entry.name}`)
     }
@@ -131,6 +125,7 @@ async function getDirEntries (path) {
 async function populateKVFile (path, file) {
   const appendFile = promisify(fs.appendFile)
   const readFile = promisify(fs.readFile)
+  if (path.slice(-1) !== pathModule.sep) path += pathModule.sep
   const entries = await getDirEntries(path)
 
   await appendFile(file, '{\n')

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,7 @@
 const fs = require('fs')
+const {promisify} = require('util')
+const pathModule = require('path')
+const tmp = require('tmp')
 const {KeyValueStore} = require('./kv')
 module.exports.read = f => fs.readFileSync(f).toString('utf-8')
 module.exports.extractKVBindings = (kvSetFlags, kvFileFlags) => {
@@ -82,4 +85,97 @@ function parseFlags (type, flags = [], objectVariable = false, handleVariable = 
   }
 
   return bindings
+}
+
+/**
+ * Recursively generate a list of files in a given directory and its subdirectories.
+ *
+ * @param {string} path The path to the directory.
+ *
+ * @returns {Array<string>} List of files in the directory and its subdirectories, relative to path.
+ */
+async function getDirEntries (path) {
+  const stat = promisify(fs.stat)
+  const readdir = promisify(fs.readdir)
+  if (path.slice(-1) !== pathModule.sep) path += pathModule.sep
+
+  if (!await stat(path)) {
+    throw new Error(`Path does not exist: ${path}`)
+  }
+
+  let entries = []
+
+  const dir = await readdir(path, { withFileTypes: true })
+  for (const entry of dir) {
+    if (entry.isDirectory()) {
+      entries = entries.concat(await getDirEntries(`${path}${entry.name}`))
+    } else {
+      entries.push(`${path}${entry.name}`)
+    }
+  }
+
+  return entries
+}
+
+/*
+ * Create a JSON file suitable for populating an in-memory KV store, as well as a manifest
+ * file mapping paths to entries in the KV store.
+ *
+ * @param {string} path The path to the directory to generate the KV file JSON from.
+ * @param {string} file The path to the JSON file.
+ *
+ * @returns {Object}
+ *   @property {string} file The path to the KV store JSON file.
+ *   @property {string} manifestFile The path to the manifest binding JSON file.
+ */
+async function populateKVFile (path, file) {
+  const appendFile = promisify(fs.appendFile)
+  const readFile = promisify(fs.readFile)
+  const entries = await getDirEntries(path)
+
+  await appendFile(file, '{\n')
+  let entry, contents
+  for (let index = 0; index < entries.length; index++) {
+    entry = entries[index]
+    contents = await readFile(`${entry}`, { encoding: 'utf-8' })
+    entry = entry.replace(path, '')
+
+    await appendFile(
+      file,
+      `  ${JSON.stringify(entry)}: ${JSON.stringify(contents)}` +
+      (index < entries.length - 1 ? ',' : '') +
+      '\n'
+    )
+  }
+  await appendFile(file, '}\n')
+
+  const manifestFile = file.replace('.json', '-manifest.json')
+  const manifestKeys = {}
+  for (const key of entries) {
+    const shortKey = key.replace(path, '')
+    manifestKeys[shortKey] = shortKey
+  }
+
+  await appendFile(manifestFile, JSON.stringify(manifestKeys))
+
+  return { file, manifestFile }
+}
+
+/**
+ * Generate the necessary KV store and binding for a static site using the
+ * assets in a given directory.
+ *
+ * @param {string} bucketPath The path to the static site's asset bucket.
+ *
+ * @returns {Object}
+ *   @property {string} siteKvFile The --kv-file param for the static content KV file.
+ *   @property {string} siteManifest The --bind-file param for the static content manifest file.
+ */
+module.exports.generateSite = async (bucketPath) => {
+  const tmpFile = tmp.fileSync({ prefix: 'cloudworker-', postfix: '.json' })
+  const { file, manifestFile } = await populateKVFile(bucketPath, tmpFile.name)
+  return {
+    siteKvFile: `__STATIC_CONTENT=${file}`,
+    siteManifest: `__STATIC_CONTENT_MANIFEST=${manifestFile}`,
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2353,6 +2353,17 @@
             "chardet": "^0.4.0",
             "iconv-lite": "^0.4.17",
             "tmp": "^0.0.33"
+          },
+          "dependencies": {
+            "tmp": {
+              "version": "0.0.33",
+              "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+              "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+              "dev": true,
+              "requires": {
+                "os-tmpdir": "~1.0.2"
+              }
+            }
           }
         },
         "fast-deep-equal": {
@@ -2817,6 +2828,17 @@
         "chardet": "^0.7.0",
         "iconv-lite": "^0.4.24",
         "tmp": "^0.0.33"
+      },
+      "dependencies": {
+        "tmp": {
+          "version": "0.0.33",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+          "dev": true,
+          "requires": {
+            "os-tmpdir": "~1.0.2"
+          }
+        }
       }
     },
     "extglob": {
@@ -3039,8 +3061,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.4",
@@ -3062,7 +3083,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3105,7 +3127,8 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -3116,7 +3139,8 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3233,7 +3257,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3245,6 +3270,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3267,12 +3293,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3291,6 +3319,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3371,7 +3400,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3383,6 +3413,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3468,7 +3499,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3504,6 +3536,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3523,6 +3556,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3566,12 +3600,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3617,7 +3653,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3946,7 +3981,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3955,8 +3989,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "6.4.1",
@@ -5531,7 +5564,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -5693,8 +5725,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -7083,12 +7114,21 @@
       "dev": true
     },
     "tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
+      "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "rimraf": "^2.6.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "tmpl": {
@@ -7680,8 +7720,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "homepage": "https://github.com/dollarshaveclub/cloudworker#readme",
   "dependencies": {
     "@dollarshaveclub/node-fetch": "^3.2.0",
-    "web-streams-polyfill": "^2.0.3",
     "arraybuffer-equal": "^1.0.4",
     "atob": "^2.1.2",
     "btoa": "^1.2.1",
@@ -41,7 +40,9 @@
     "http-cache-semantics": "^4.0.3",
     "lru-cache": "^5.1.1",
     "moment": "^2.24.0",
-    "node-webcrypto-ossl": "^1.0.48"
+    "node-webcrypto-ossl": "^1.0.48",
+    "tmp": "^0.1.0",
+    "web-streams-polyfill": "^2.0.3"
   },
   "devDependencies": {
     "@types/node": "^10.14.10",


### PR DESCRIPTION
This builds on #132 to support simulating a Workers Sites static site deployment in cloudworker, by adding functionality to recursively read a specified bucket directory and create a temporary KV file as well as a manifest `text_blob` binding the same way that wrangler does when deploying a static site.

Run it in a static site project directory via e.g. `cloudworker --debug --site-bucket public/ dist/main.js`