### PR TITLE
fix `new Function(<string>)` allowing for arbitrary code execution

### DIFF
--- a/lib/__tests__/cloudworker.test.js
+++ b/lib/__tests__/cloudworker.test.js
@@ -165,4 +165,14 @@ describe('cloudworker', () => {
     expect(res.headers.get('x-colo')).toEqual('YYZ')
     done()
   })
+
+  test('throws on eval', async () => {
+    const bindings = { EvalError: EvalError }
+    expect(() => { new Cloudworker(`eval('true')`, { bindings }) }).toThrow(new EvalError('Code generation from strings disallowed for this context')) // eslint-disable-line no-new
+  })
+
+  test('throws on new Function(<string>)', async () => {
+    const bindings = { EvalError: EvalError }
+    expect(() => { new Cloudworker(`new Function('true')`, { bindings }) }).toThrow(new EvalError('Code generation from strings disallowed for this context')) // eslint-disable-line no-new
+  })
 })

--- a/lib/runtime.js
+++ b/lib/runtime.js
@@ -5,6 +5,7 @@ const { FetchEvent } = require('./runtime/fetch-event')
 const { crypto } = require('./runtime/crypto')
 const { TextDecoder, TextEncoder } = require('./runtime/text-encoder')
 const { atob, btoa } = require('./runtime/base64')
+const { FunctionProxy } = require('./runtime/function')
 
 class Context {
   constructor (addEventListener, cacheFactory, bindings = {}) {
@@ -44,7 +45,7 @@ class Context {
     this.EvalError = EvalError
     this.Float32Array = Float32Array
     this.Float64Array = Float64Array
-    this.Function = Function
+    this.Function = FunctionProxy
     this.Int8Array = Int8Array
     this.Int16Array = Int16Array
     this.Int32Array = Int32Array

--- a/lib/runtime/function.js
+++ b/lib/runtime/function.js
@@ -1,0 +1,13 @@
+// We bind `Function` in from the parent for `instanceof`
+// purposes, but we don't want to disallow code generation
+// from strings with new Function(<string>). So, we use this Proxy!
+
+// Security note: there may well be ways to hack around this. Enforcing
+// this rule is about consistency with CF workers, not allowing for
+// fully untrusted code.
+
+module.exports.FunctionProxy = new Proxy(Function, {
+  construct: () => {
+    throw new EvalError('Code generation from strings disallowed for this context')
+  },
+})


### PR DESCRIPTION
Pay attention to the security note — I'm really not sure if there's a way to hack around this or not. But this at least makes us consistent with CF workers in the common case.

fixes #146 